### PR TITLE
use queues instead of runloop

### DIFF
--- a/Sources/OpenVPNAdapter/library/OpenVPNAdapterImpl.mm
+++ b/Sources/OpenVPNAdapter/library/OpenVPNAdapterImpl.mm
@@ -372,7 +372,7 @@
 }
 
 - (CFSocketNativeHandle)socketHandle {
-    return CFSocketGetNative(self.packetFlowBridge.openVPNSocket);
+    return self.packetFlowBridge.openVPNSocket;
 }
 
 - (void)clientEventName:(NSString *)eventName message:(NSString *)message {

--- a/Sources/OpenVPNAdapter/library/OpenVPNPacketFlowBridge.h
+++ b/Sources/OpenVPNAdapter/library/OpenVPNPacketFlowBridge.h
@@ -16,8 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) id<OpenVPNAdapterPacketFlow> packetFlow;
 
-@property (nonatomic, readonly) CFSocketRef openVPNSocket;
-@property (nonatomic, readonly) CFSocketRef packetFlowSocket;
+@property (nonatomic, readonly) int openVPNSocket;
+@property (nonatomic, readonly) int packetFlowSocket;
+@property (nonatomic, readonly) dispatch_source_t source;
 
 - (BOOL)configureSocketsWithError:(NSError **)error;
 - (void)invalidateSocketsIfNeeded;


### PR DESCRIPTION
This allows use of this library inside a system extension. The only way to distribute a packet tunnel provider outside of the App Store is within a system extension (using the SystemExtensions framework), but these system extensions don't have access to a runloop.